### PR TITLE
add missing (versioned) ethers dependency for the tutorials

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -4,5 +4,6 @@ import { Address, Hash, concat, createClient, createPublicClient, encodeFunction
 import { generatePrivateKey, privateKeyToAccount, signMessage } from "viem/accounts"
 import { lineaTestnet, polygonMumbai, sepolia } from "viem/chains"
 import { writeFileSync } from 'fs'
+import { ethers } from 'ethers'
 
 console.log("Hello world!")

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@fuseio/fusebox-web-sdk": "^0.2.5",
         "dotenv": "^16.4.2",
+        "ethers": "5.7",
         "viem": "^2.7.8"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@fuseio/fusebox-web-sdk": "^0.2.5",
     "dotenv": "^16.4.2",
+    "ethers": "5.7",
     "viem": "^2.7.8"
   },
   "devDependencies": {


### PR DESCRIPTION
cf. https://docs.fuse.io/docs/tutorials/tutorials/send-your-first-gasless-transaction